### PR TITLE
os module used only at master

### DIFF
--- a/resources/leiningen/new/macchiato/src/core.cljs
+++ b/resources/leiningen/new/macchiato/src/core.cljs
@@ -19,15 +19,15 @@
        :on-success #(info "{{name}} started on" host ":" port)})))
 
 (defn start-workers [os cluster]
-  (dotimes [_ (-> os .cpus .-length)]
-    (.fork cluster))
-  (.on cluster "exit"
-       (fn [worker code signal]
-         (info "worker terminated" (-> worker .-process .-pid)))))
+  (let [os (js/require "os")]
+    (dotimes [_ (-> os .cpus .-length)]
+      (.fork cluster))
+    (.on cluster "exit"
+      (fn [worker code signal]
+        (info "worker terminated" (-> worker .-process .-pid))))))
 
 (defn main [& args]
-  (let [os      (js/require "os")
-        cluster (js/require "cluster")]
+  (let [cluster (js/require "cluster")]
     (if (.-isMaster cluster)
       (start-workers os cluster)
       (app))))


### PR DESCRIPTION
Thanks for macchiato. It's super good. Macchiato inspire's me to use nodejs as backend platform.

My PR is about memory.
I respect the rule about put js/require in one place.
But it seem for me that it is more important to keep base workers light as much as possible.

Let's define os module at master process.
Let's NOT define os module at every worker process.
