### PR TITLE
Use npm start to run the builds

### DIFF
--- a/resources/leiningen/new/macchiato/README.md
+++ b/resources/leiningen/new/macchiato/README.md
@@ -15,7 +15,7 @@ lein build
 run `node` in another terminal:
 
 ```
-node target/out/{{name}}.js
+npm start
 ```
 
 #### configuring the REPL
@@ -34,5 +34,5 @@ lein package
 Run the release version:
 
 ```
-node target/release/{{name}}.js
+npm start
 ```

--- a/resources/leiningen/new/macchiato/project.clj
+++ b/resources/leiningen/new/macchiato/project.clj
@@ -22,7 +22,9 @@
   :target-path "target"
   :profiles
   {:dev
-   {:cljsbuild
+   {:npm {:package {:main "target/out/{{name}}.js"
+                    :scripts {:start "node target/out/{{name}}.js"}}}
+    :cljsbuild
     {:builds {:dev
               {:source-paths ["env/dev" "src"]
                :figwheel     true
@@ -54,7 +56,9 @@
                       :source-map    true}}}}
     :doo {:build "test"}}
    :release
-   {:cljsbuild
+   {:npm {:package {:main "target/release/{{name}}.js"
+                    :scripts {:start "node target/release/{{name}}.js"}}}
+    :cljsbuild
     {:builds
      {:release
       {:source-paths ["env/prod" "src"]

--- a/resources/leiningen/new/macchiato/project.clj
+++ b/resources/leiningen/new/macchiato/project.clj
@@ -75,7 +75,7 @@
    "package" ["do"
               ["clean"]
               ["npm" "install"]
-              ["npm" "init" "-y"]
+              ["with-profile" "release" "npm" "init" "-y"]
               ["with-profile" "release" "cljsbuild" "once"]]
    "test" ["do"
            ["npm" "install"]


### PR DESCRIPTION
I added `:main` and `:scripts :start` entries in the npm package configuration both for dev and release profiles. This causes the main and start script properties to be populated in package.json (which is kind of a standard) but also allows to run the builds with `npm start` instead of  `node target/out/{{name}}.js` and `node target/release/{{name}}.js`