### PR TITLE
allow lein repl to work

### DIFF
--- a/resources/leiningen/new/macchiato/project.clj
+++ b/resources/leiningen/new/macchiato/project.clj
@@ -24,6 +24,7 @@
   {:dev
    {:npm {:package {:main "target/out/{{name}}.js"
                     :scripts {:start "node target/out/{{name}}.js"}}}
+    :dependencies [[figwheel-sidecar "0.5.10"]]
     :cljsbuild
     {:builds {:dev
               {:source-paths ["env/dev" "src"]


### PR DESCRIPTION
`lein repl` does not work out of the box because the figwheel-sidecar namespace isn't available