### PR TITLE
fix a issue with paths on Windows

### DIFF
--- a/resources/leiningen/new/macchiato/project.clj
+++ b/resources/leiningen/new/macchiato/project.clj
@@ -9,7 +9,7 @@
                  [macchiato/env "0.0.6"]
                  [mount "0.1.11"]
                  [org.clojure/clojure "1.8.0"]
-                 [org.clojure/clojurescript "1.9.908"]]
+                 [org.clojure/clojurescript "1.9.946"]]
   :min-lein-version "2.0.0"
   :jvm-opts ^:replace ["-Xmx1g" "-server"]
   :plugins [[lein-doo "0.1.7"]


### PR DESCRIPTION
A fix for isssue #7 
CLJS-2345: escape paths emitted as args to cljs.core.load_file (https://github.com/clojure/clojurescript/commit/b74538b4e9947973175cf197704c18b10a5ce6bf)

 