### PR TITLE
Improve test output

### DIFF
--- a/resources/leiningen/new/macchiato/project.clj
+++ b/resources/leiningen/new/macchiato/project.clj
@@ -78,7 +78,8 @@
                       :optimizations :none
                       :pretty-print  true
                       :source-map    true}}}}
-    :doo {:build "test"}}
+    :doo {:build "test"}
+    :dependencies [[pjstadig/humane-test-output "0.8.3"]]}
    :release
    {:npm {:package {:main "target/release/{{name}}.js"
                     :scripts {:start "node target/release/{{name}}.js"}}}

--- a/resources/leiningen/new/macchiato/test/core_test.cljs
+++ b/resources/leiningen/new/macchiato/test/core_test.cljs
@@ -1,5 +1,6 @@
 (ns {{project-ns}}.core-test
-  (:require
+    (:require
+    [pjstadig.humane-test-output]
     [cljs.test :refer-macros [is are deftest testing use-fixtures]]
     [{{project-ns}}.core]))
 


### PR DESCRIPTION
Hi. As you may know, it might take a while to figure out which part of test output is wrong in many tests.

Example of such test:
```clojure
(deftest map-test
  (is (= {:a "a"
          :b "b"}
         {:a "b"
          :b "b"})))
```

Output of `$ lein test` without this pr:
```
FAIL in (map-test) (cljs/test.cljs:476:9)
expected: (= {:a "a", :b "b"} {:a "b", :b "b"})
  actual: (not (= {:a "a", :b "b"} {:a "b", :b "b"}))
```

Output of `$ lein test` with this pr:
```
FAIL in (map-test) (cljs/core.cljs:3843:7)

expected: {:a "a", :b "b"}
  actual: {:a "b", :b "b"}

    diff: - {:a "a"}
          + {:a "b"}
```